### PR TITLE
Link cached results to the name of the source data file

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Ruby edition of the [1BRC](https://github.com/gunnarmorling/1brc/tree/main) Java
 bundle install
 
 # 10 million measurements, ~10 seconds to generate on an M1 Macbook Pro.
-bundle exec ruby create_measurements.rb 1000000
+bundle exec ruby create_measurements.rb 10000000
 
 # Rename for use with the spec
 mv measurements.txt measurements_test.txt

--- a/spec/challenge_spec.rb
+++ b/spec/challenge_spec.rb
@@ -31,13 +31,13 @@ RSpec.describe Challenge do
   end
 
   let(:cached_perform_simple_result) do
-    get_via_cache("simple_result.json", measurements_test_file_key) do
+    get_via_cache("#{File.basename(measurements_test_file_key, '.txt')}.simple_result.json", measurements_test_file_key) do
       challenge.perform_simple
     end
   end
 
   let(:cached_perform_simple_total_time) do
-    get_via_cache("simple_bench.json", measurements_test_file_key) do
+    get_via_cache("#{File.basename(measurements_test_file_key, '.txt')}.simple_bench.json", measurements_test_file_key) do
       Benchmark.measure { challenge.perform_simple }.total
     end
   end


### PR DESCRIPTION
I think it might be nice if the cached data is keyed on the name of the source data file. That way, we don't need to remember to delete the cached data when changing from `measurements_test.txt` to `measurements.txt`.